### PR TITLE
코드 블록 레이아웃 및 투명도 조정

### DIFF
--- a/src/app/components/CodeOrderingQuiz.tsx
+++ b/src/app/components/CodeOrderingQuiz.tsx
@@ -58,7 +58,7 @@ function SortableLine({ item }: { item: LineItem }) {
       {...listeners}
       className={`
         group relative
-        p-3 rounded-xl
+        p-2 md:p-2.5 rounded-xl
         bg-white/10 dark:bg-slate-800/40
         border border-white/20 dark:border-white/10
         backdrop-blur-md
@@ -68,10 +68,10 @@ function SortableLine({ item }: { item: LineItem }) {
         ${isDragging ? 'opacity-50 scale-105 shadow-2xl z-50' : 'shadow-md'}
       `}
     >
-      <div className="flex items-center gap-3">
-        {/* 드래그 핸들 아이콘 */}
-        <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <div className="flex items-center gap-2">
+        {/* 드래그 핸들 아이콘 - 투명하게 */}
+        <div className="flex-shrink-0 text-gray-400/40 dark:text-gray-500/30 group-hover:text-gray-600/60 dark:group-hover:text-gray-400/50 transition-colors">
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8h16M4 16h16" />
           </svg>
         </div>
@@ -109,7 +109,8 @@ export default function CodeOrderingQuiz({
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 5, // 5px 이동해야 드래그 시작 (터치 오동작 방지)
+        distance: 3, // 3px로 줄여서 더 민감하게 반응
+        tolerance: 5, // 드래그 중 5px 오차 허용으로 떨림 방지
       },
     })
   );


### PR DESCRIPTION
Maximize code block visibility and improve touch drag stability in `CodeOrderingQuiz`.

The previous layout had excessive padding and a prominent drag handle, reducing the effective code area, particularly on mobile. The touch drag experience was also prone to jitter. This PR addresses these by reducing visual clutter and refining the drag sensor's activation constraints for a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-02366f07-e134-4202-980e-7d9d4f1bec4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02366f07-e134-4202-980e-7d9d4f1bec4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

