### PR TITLE
Update array state with spread and concat

### DIFF
--- a/content/2025-07-21-react-learning-02-07-array-state.mdx
+++ b/content/2025-07-21-react-learning-02-07-array-state.mdx
@@ -35,10 +35,15 @@ JavaScript에서 배열은 변경 가능하지만, state에 저장할 때는 **�
 
 `push()` 대신 spread 문법이나 `concat()`을 사용해야 합니다.
 
+**Spread 문법 사용 예제:**
+
 ```jsx
 import { useState } from 'react';
 
+let nextId = 0;
+
 export default function List() {
+  const [name, setName] = useState('');
   const [artists, setArtists] = useState([]);
 
   return (
@@ -53,6 +58,7 @@ export default function List() {
           ...artists,                    // 기존 배열 복사
           { id: nextId++, name: name }   // 새 요소 추가
         ]);
+        setName('');  // 입력 필드 초기화
       }}>
         Add
       </button>
@@ -66,10 +72,48 @@ export default function List() {
 }
 ```
 
-**Spread 문법:**
+**`concat()` 메서드 사용 예제:**
 
-- `[...artists, newItem]`: 끝에 추가
-- `[newItem, ...artists]`: 시작에 추가
+```jsx
+import { useState } from 'react';
+
+let nextId = 0;
+
+export default function List() {
+  const [name, setName] = useState('');
+  const [artists, setArtists] = useState([]);
+
+  return (
+    <>
+      <h1>Inspiring sculptors:</h1>
+      <input
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <button onClick={() => {
+        // concat()은 새 배열을 반환하므로 불변성 유지
+        setArtists(
+          artists.concat({ id: nextId++, name: name })
+        );
+        setName('');  // 입력 필드 초기화
+      }}>
+        Add
+      </button>
+      <ul>
+        {artists.map(artist => (
+          <li key={artist.id}>{artist.name}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+```
+
+**비교:**
+
+- **Spread 문법**: `[...artists, newItem]` - 끝에 추가, `[newItem, ...artists]` - 시작에 추가
+- **`concat()` 메서드**: `artists.concat(newItem)` - 끝에 추가, `[newItem].concat(artists)` - 시작에 추가
+- 두 방법 모두 새 배열을 반환하므로 불변성을 유지합니다
 
 ### 배열에서 요소 제거하기
 


### PR DESCRIPTION
Fix incomplete example code for adding array elements and add a `concat()` example for comparison.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbdaa9ab-f61d-44c8-9d0c-8721e324b82a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbdaa9ab-f61d-44c8-9d0c-8721e324b82a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

